### PR TITLE
Byte is not supported by SQLite 3 so I switched to int.

### DIFF
--- a/mobile/src/main/java/com/zacharytamas/often/models/Habit.java
+++ b/mobile/src/main/java/com/zacharytamas/often/models/Habit.java
@@ -11,10 +11,10 @@ import java.util.Date;
 public class Habit extends SugarRecord<Habit> {
     public String title = "";
     public Boolean required = true;
-    public byte repeatType = 0;
+    public int repeatType = 0;
     public int repeatUnit = 0;
     public int repeatScalar = 0;
-    public Byte repeatWeekdays = 0;
+    public int repeatWeekdays = 0;
     public Date createdAt = new Date();
     public Date availableAt;
     public Date lastCompletedAt;

--- a/mobile/src/main/java/com/zacharytamas/often/utils/Dates.java
+++ b/mobile/src/main/java/com/zacharytamas/often/utils/Dates.java
@@ -16,11 +16,11 @@ import java.util.GregorianCalendar;
  */
 public class Dates {
 
-    public static Boolean getBitForWeekday(Byte mask, int weekday) {
+    public static Boolean getBitForWeekday(int mask, int weekday) {
         return (mask & (1 << (weekday - 1))) > 0;
     }
 
-    public static Byte setBitForWeekday(Byte mask, int weekday, Boolean repeat) {
+    public static Byte setBitForWeekday(int mask, int weekday, Boolean repeat) {
         int weekdayBit = weekday - 1;
         if (repeat) {  // set the bit
             return (byte) (mask | (1 << weekdayBit));


### PR DESCRIPTION
I originally chose byte just because it was smaller and I'm only using one byte's worth of bits anyway. I figured this would save memory, but it turns out that SQLite 3 works with one Integer type and stores it with a variable amount of bits so it's the best of both worlds.
